### PR TITLE
fix: Remove the custom hostname to make it easier to execute locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,21 +91,9 @@ helm upgrade \
 stock-ticker helm/stock-ticker
 ```
 
-Get the IP:
-
-```bash
-docker container inspect stock-ticker-control-plane \
-  --format '{{ .NetworkSettings.Networks.kind.IPAddress }}'
-```
-
-Add it to the `/etc/hosts` file with:
-```
-172.18.0.2 stock-ticker.local
-```
-
 Execute the API:
 ```
-curl http://stock-ticker.local --silent
+curl http://localhost/price --silent
 ```
 
 To clean up:

--- a/helm/stock-ticker/templates/ingress.yaml
+++ b/helm/stock-ticker/templates/ingress.yaml
@@ -39,7 +39,7 @@ spec:
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
-      http:
+     - http:
         paths:
           {{- range .paths }}
           - path: {{ .path }}


### PR DESCRIPTION
Removed the custom hostname to simplify the local execution.